### PR TITLE
processContent function added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-node_modules/
+node_modules
 tmp
+
+# user IDE
+nbproject

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,16 @@ module.exports = function (grunt) {
         },
         src: 'test/fixtures/**/*.json',
         dest: 'tmp/global_namespace_options.js'
+      },
+      process_content_options: {
+        options: {
+          processContent: function(content) {
+            content.myVar = 'myVal';
+            return content;
+          }
+        },
+        src: 'test/fixtures/**/*.json',
+        dest: 'tmp/process_content_options.js'
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,22 @@ options: {
 }
 ```
 
-#commonjs
+#### processContent
+Type: `function`
+Default: null
+
+This option accepts a function which takes one argument (content) and returns a modified content of the JSON file. The example below appends a custom attribute to the JSON file content.
+
+```js
+options: {
+  processContent: function(content) {
+    content.myVar = 'myVal';
+    return content;
+  }
+}
+```
+
+####commonjs
 Type: `Boolean`
 Default: false
 

--- a/tasks/json.js
+++ b/tasks/json.js
@@ -12,19 +12,18 @@
 module.exports = function (grunt) {
     var path = require('path');
 
-    var defaultProcessNameFunction = function (name) {
-        return name;
+    var pass = function (value) {
+        return value;
     };
 
-    var concatJson = function (files, data) {
-        var options = data.options;
-        var namespace = options && options.namespace || 'myjson';               // Allows the user to customize the namespace but will have a default if one is not given.
-        var includePath = options && options.includePath || false;              // Allows the user to include the full path of the file and the extension.
-        var processName = options.processName || defaultProcessNameFunction;    // Allows the user to modify the path/name that will be used as the identifier.
+    var concatJson = function (files, options) {
+        var namespace = options && options.namespace || 'myjson';    // Allows the user to customize the namespace but will have a default if one is not given.
+        var includePath = options && options.includePath || false;   // Allows the user to include the full path of the file and the extension.
+        var processName = options.processName || pass;               // Allows the user to modify the path/name that will be used as the identifier.
+        var processContent = options.processContent || pass;         // Allows the user to process JSON file content on the fly
         var commonjs = options.commonjs || false;
-        var basename;
-        var filename;
         var NEW_LINE_REGEX = /\r*\n/g;
+        var basename, filename, content;
 
         var varDeclecation;
         if (commonjs) {
@@ -36,7 +35,8 @@ module.exports = function (grunt) {
         return varDeclecation + files.map(function (filepath) {
             basename = path.basename(filepath, '.json');
             filename = (includePath) ? processName(filepath) : processName(basename);
-            return '\n' + namespace + '["' + filename + '"] = ' + grunt.file.read(filepath).replace(NEW_LINE_REGEX, '') + ';';
+            content = processContent(grunt.file.readJSON(filepath));
+            return '\n' + namespace + '["' + filename + '"] = ' + JSON.stringify(content, null, 2).replace(NEW_LINE_REGEX, '') + ';';
         }).join('');
     };
 
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
     // ==========================================================================
 
     grunt.registerMultiTask('json', 'Concatenating JSON into JS', function () {
-        var data = this.data;
+        var options = this.options();
         grunt.util.async.forEachSeries(this.files, function (f, nextFileObj) {
             var destFile = f.dest;
             var files = f.src.filter(function (filepath) {
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
                 }
             });
 
-            var json = concatJson(files, data);
+            var json = concatJson(files, options);
             grunt.file.write(destFile, json);
             grunt.log.write('File "' + destFile + '" created.');
         });

--- a/test/expected/process_content_options.js
+++ b/test/expected/process_content_options.js
@@ -1,0 +1,4 @@
+var myjson = myjson || {};
+myjson["de"] = {  "de_key1": "value",  "de_key2": "value",  "myVar": "myVal"};
+myjson["en"] = {  "en_key1": "key1",  "en_key2": "key2",  "myVar": "myVal"};
+myjson["folder"] = {  "folder_key1": "value",  "folder_key2": "value",  "myVar": "myVal"};

--- a/test/json_test.js
+++ b/test/json_test.js
@@ -50,5 +50,13 @@ exports['json'] = {
 
     test.done();
   },
+  process_content_options: function (test) {
+    test.expect(1);
+    var actual = grunt.file.read('tmp/process_content_options.js');
+    var expected = grunt.file.read('test/expected/process_content_options.js');
+    test.equal(actual, expected, 'should concat json and export');
+
+    test.done();
+  }
 
 };


### PR DESCRIPTION
`processContent` is a function that allows to modify the JSON file on the fly. The function gets the original file content, modifies it and returns the new content which will be dumped. It is extremely useful when you want to modify the JSON before dumping it (e.g. applying CLI options to dumped JSON files). I didn't want to write my own plugin for that, hence the PR :)

changes:
* removed `.data` grunt attribute which is deprecated, passing `options`
* replaced grunt.file.readJSON with grunt.file.read, since this method is better for reading JSON content, added JSON.stringify to dump the output.
* added test for new feature

minor changes:
* added netbeans to gitignore
* updated docs markdown: commonjs option was added incorrectly (syntax issue)